### PR TITLE
Correction faute d'orthographe

### DIFF
--- a/lang/fr/tpl/contract/insertChoose.mtt
+++ b/lang/fr/tpl/contract/insertChoose.mtt
@@ -15,7 +15,7 @@
 		
 		<p>
 			C'est un contrat avec un engagement à l'année ou à la saison. 
-			Les produits sont toujours les même à chaque livraison.
+			Les produits sont toujours les mêmes à chaque livraison.
 		</p>
 		<p>
 			


### PR DESCRIPTION
Accord entre "les" et "mêmes" ([voir](http://www.francaisfacile.com/exercices/exercice-francais-2/exercice-francais-48619.php)) sur la description du contrat AMAP.