### PR TITLE
Change the displayed version from "july" to the date of the last commit

### DIFF
--- a/src/App.hx
+++ b/src/App.hx
@@ -15,7 +15,8 @@ class App extends sugoi.BaseApp {
 	 * Version management
 	 * @doc https://github.com/fponticelli/thx.semver
 	 */ 
-	public static var VERSION = ([0,9,2]  : Version).withPre("july");
+	//public static var VERSION = ([0,9,2]  : Version).withPre("july");
+	public static var VERSION = ([0,9,2]  : Version).withPre(MyMacros.getGitCommitDate());
 	
 	public static function main() {
 		

--- a/src/MyMacros.hx
+++ b/src/MyMacros.hx
@@ -1,0 +1,35 @@
+import haxe.macro.Expr;
+import haxe.macro.Context;
+import StringTools;
+
+class MyMacros {
+	/* based on 
+	http://code.haxe.org/category/macros/add-git-commit-hash-in-build.html 
+	http://stackoverflow.com/questions/8611486/how-to-get-the-last-commit-date-for-a-bunch-of-files-in-git*/
+	public static macro function getGitCommitDate():haxe.macro.ExprOf<String> {
+	    #if !display
+	    var process = new sys.io.Process('git', ['log', '-1', '--format=%ci']);
+	    if (process.exitCode() != 0) {
+	      var message = process.stderr.readAll().toString();
+	      var pos = haxe.macro.Context.currentPos();
+	      Context.error("Cannot execute `git log -1 --format=%ci`. " + message, pos);
+	    }
+	    
+	    // read the output of the process
+	    var commitDate:String = process.stdout.readLine();
+	    commitDate = StringTools.replace(commitDate, " ", "-");
+	    commitDate = StringTools.replace(commitDate, ":", "-");
+	    commitDate = commitDate.substr(0,16);
+	    commitDate = "D"+commitDate;
+	    //trace (commitDate);
+	    
+	    // Generates a string expression
+	    return macro $v{commitDate};
+	    #else 
+	    // `#if display` is used for code completion. In this case returning an
+	    // empty string is good enough; We don't want to call git on every hint.
+	    var commitDate:String = "";
+	    return macro $v{commitDate};
+	    #end
+  	}
+}


### PR DESCRIPTION
Ce commit change l'affichage de bas de page 
	....Twitter • version 0.9.2-july-Neko
en 
	....Twitter • version 0.9.2-D2016-11-25-17-14-Neko
qui est la date (et heure/minute) du dernier commit.
Pour des fins de traçabilité et être sûr que ce que l'on visualise est bien ce que l'on a compilé.