### PR TITLE
Ajoute le host name dans la "user/login" page

### DIFF
--- a/lang/fr/tpl/design.mtt
+++ b/lang/fr/tpl/design.mtt
@@ -6,8 +6,15 @@
 				::if user!=null && user.getAmap()!=null::
 					<h1>::user.getAmap().name::</h1>
 				::else::
-					<h1 style="margin-bottom:22px;"><a href="/">Cagette.net</a></h1>
-					
+					<table><tr>
+					<td><h1 style="margin-bottom:22px;"><a href="/">Cagette.net</a></h1></td>
+					<td width="12%"></td>
+					<td id="hostURL"></td>
+					</tr></table>
+					<script language="JavaScript">
+						var x = " hébergé par " + window.location.protocol + "//" + window.location.host;
+						document.getElementById("hostURL").innerHTML = x;;	
+					</script>					
 				::end::
 				
 			</div>


### PR DESCRIPTION
A la lecture du forum, je me rends compte qu'il y a plusieurs hébergeurs de cagette.net. Hors la page de login a le même aspect quelque soit l'hébergeur.
Ce commit permet de rappeler de manière plus visible dans cettepage de login, quel est l'hébergeur utilisé afin de ne pas confondre différentes installations