### PR TITLE
Mail lors de l'ouverture des commandes

### DIFF
--- a/src/App.hx
+++ b/src/App.hx
@@ -124,6 +124,7 @@ class App extends sugoi.BaseApp {
 		out.set("HasEmailNotif4h", "Recevoir des notifications par email 4h avant les distributions");
 		out.set("24h", "Recevoir des notifications par email 24h avant les distributions");
 		out.set("HasEmailNotif24h", "Recevoir des notifications par email 24h avant les distributions");
+		out.set("Ouverture", "Recevoir des notifications par email pour l'ouverture des commandes");
 		out.set("Tuto", "Activer tutoriels");
 		out.set("HasMembership", "Gestion des adhésions");
 		out.set("DayOfWeek", "Jour de la semaine");

--- a/src/MyMacros.hx
+++ b/src/MyMacros.hx
@@ -43,6 +43,7 @@ class MyMacros {
 	    
 	    // read the output of the process
 	    var commitShortSHA:String = process.stdout.readLine();
+	    commitShortSHA = "C"+commitShortSHA;
 	    
 	    // Generates a string expression
 	    return macro $v{commitShortSHA};

--- a/src/controller/Cron.hx
+++ b/src/controller/Cron.hx
@@ -178,13 +178,14 @@ class Cron extends Controller
 		var users = new Map <String,{
 			user:db.User,
 			distrib:db.Distribution,
-			products:Array<db.UserContract>			
+			products:Array<db.UserContract>,
+			vendors:Array<db.Vendor>		
 		}>();
 		
 		for (o in orders) {
 			
 			var x = users.get(o.userId+"-"+o.product.contract.amap.id);
-			if (x == null) x = {user:o.user,distrib:null,products:[]};
+			if (x == null) x = {user:o.user,distrib:null,products:[],vendors:[]};
 			x.distrib = distribsByContractId.get(o.product.contract.id);
 			//x.distrib = o.distribution;
 			x.products.push(o);			
@@ -194,7 +195,7 @@ class Cron extends Controller
 			// Prévenir également le deuxième user en cas des commandes alternées
  			if (o.user2 != null) {
  				var x = users.get(o.user2.id+"-"+o.product.contract.amap.id);
- 				if (x == null) x = {user:o.user2,distrib:null,products:[]};
+ 				if (x == null) x = {user:o.user2,distrib:null,products:[],vendors:[]};
  				x.distrib = distribsByContractId.get(o.product.contract.id);
  				x.products.push(o);
  				users.set(o.user2.id+"-"+o.product.contract.amap.id, x);
@@ -209,8 +210,9 @@ class Cron extends Controller
 				var MemberList = d.contract.amap.getMembers();
 				for (u in MemberList) {
 					var x = users.get(u.id+"-"+d.contract.amap.id);
-					if (x == null) x = {user:u,distrib:null,products:[]};
-					x.distrib = distribsByContractId.get(d.contract.id);	
+					if (x == null) x = {user:u,distrib:null,products:[],vendors:[]};
+					x.distrib = distribsByContractId.get(d.contract.id);
+					x.vendors.push(d.contract.vendor);
 					users.set(u.id+"-"+d.contract.amap.id, x);
 					trace (u.id+"-"+d.contract.amap.id, x);Sys.print("<br/>\n");
 				}
@@ -228,6 +230,11 @@ class Cron extends Controller
 					if ( db.User.UserFlags.HasEmailNotifOuverture == flag ) //ouverture de commande
 					{
 						text  = "Ouverture des commandes pour la distribution du : <b>" + view.hDate(u.distrib.date) + "</b><br>";
+						text += "Cela concerne les fournisseurs suivants :<br><ul>";
+						for ( v in u.vendors) {
+							text += "<li>" + v + "</li>";
+						}
+						text += "</ul>";
 						var url = "http://" + App.config.HOST + "/group/"+ u.distrib.contract.amap.id;
 						text += "L'adresse de votre cagette est : <a href=\"" + url + "\">" + url + "</a><br>";
 					}

--- a/src/controller/Cron.hx
+++ b/src/controller/Cron.hx
@@ -39,10 +39,13 @@ class Cron extends Controller
 	}
 	
 	public function doHour() {
+		// this function could be locally tested by
+		// cd /data/cagette/www/ && (rm page.html; neko index.n cron/hour > page.html)
 		app.event(HourlyCron);
 		
 		distribNotif(4,db.User.UserFlags.HasEmailNotif4h); //4h before
 		distribNotif(24,db.User.UserFlags.HasEmailNotif24h); //24h before
+		distribNotif(0,db.User.UserFlags.HasEmailNotifOuverture); //on command open
 	}
 	
 	
@@ -105,16 +108,26 @@ class Cron extends Controller
  		//on recherche celles qui commencent jusqu'à une heure avant pour ne pas en rater 
  		var d = DateTools.delta(Date.now(), 1000.0 * 60 * 60 * (hour-1));
  		var h = DateTools.delta(Date.now(), 1000.0 * 60 * 60 * hour);
-		var distribs = db.Distribution.manager.search( $date >= d && $date <= h , false);
+		var distribs ;
+		// dans le cas HasEmailNotifOuverture la date à prendre est le orderStartDate
+		// et non pas date qui est la date de la distribution
+		if ( db.User.UserFlags.HasEmailNotifOuverture == flag )
+			distribs = db.Distribution.manager.search( $orderStartDate >= d && $orderStartDate <= h , false);
+		else
+			distribs = db.Distribution.manager.search( $date >= d && $date <= h , false);
 		
-		//trace("distribNotif "+hour+" from "+d+" to "+h);
+		//trace("distribNotif "+hour+" from "+d+" to "+h);Sys.print("<br/>\n");
 		
 		//on s'arrete immédiatement si aucune distibution trouvée
  		if (distribs.length == 0) return;
 		
 		//cherche plus tard si on a pas une "grappe" de distrib
 		while (true) {
-			var extraDistribs = db.Distribution.manager.search( $date >= h && $date <DateTools.delta(h,1000.0*60*60) , false);			
+			var extraDistribs ;
+			if ( db.User.UserFlags.HasEmailNotifOuverture != flag )
+				extraDistribs = db.Distribution.manager.search( $date >= h && $date <DateTools.delta(h,1000.0*60*60) , false);	
+			else	
+				extraDistribs = db.Distribution.manager.search( $orderStartDate >= h && $orderStartDate <DateTools.delta(h,1000.0*60*60) , false);
 			for ( e in extraDistribs) distribs.add(e);
 			if (extraDistribs.length > 0) {
 				//on fait un tour de plus avec une heure plus tard
@@ -131,6 +144,7 @@ class Cron extends Controller
 		if (dist != null) {
 			for (d in Lambda.array(distribs)) {
 				if (Lambda.exists(dist, function(x) return x == d.id)) {
+					// Comment this line in case of local test
 					distribs.remove(d);
 				}
 			}
@@ -146,7 +160,7 @@ class Cron extends Controller
 		Cache.set(cacheId, dist, 24 * 60 * 60);
 		
 		//We have now the distribs we want to notify about.
-		//trace(distribs);
+		trace(distribs);Sys.print("<br/>\n");
 		var distribsByContractId = new Map<Int,db.Distribution>();
 		for (d in distribs) distribsByContractId.set(d.contract.id, d);
 
@@ -175,7 +189,8 @@ class Cron extends Controller
 			//x.distrib = o.distribution;
 			x.products.push(o);			
 			users.set(o.userId+"-"+o.product.contract.amap.id, x);
-			
+			trace (o.userId+"-"+o.product.contract.amap.id, x);Sys.print("<br/>\n");
+			 
 			// Prévenir également le deuxième user en cas des commandes alternées
  			if (o.user2 != null) {
  				var x = users.get(o.user2.id+"-"+o.product.contract.amap.id);
@@ -183,9 +198,25 @@ class Cron extends Controller
  				x.distrib = distribsByContractId.get(o.product.contract.id);
  				x.products.push(o);
  				users.set(o.user2.id+"-"+o.product.contract.amap.id, x);
+ 				trace (o.user2.id+"-"+o.product.contract.amap.id, x);Sys.print("<br/>\n");
  			}
 		}
 		
+		// Dans le cas de l'ouverture de commande, ce sont tous les users qu'il faut intégrer
+		if ( db.User.UserFlags.HasEmailNotifOuverture == flag )
+		{
+ 			for (d in distribs) {
+				var MemberList = d.contract.amap.getMembers();
+				for (u in MemberList) {
+					var x = users.get(u.id+"-"+d.contract.amap.id);
+					if (x == null) x = {user:u,distrib:null,products:[]};
+					x.distrib = distribsByContractId.get(d.contract.id);	
+					users.set(u.id+"-"+d.contract.amap.id, x);
+					trace (u.id+"-"+d.contract.amap.id, x);Sys.print("<br/>\n");
+				}
+			}
+		}
+
 		for ( u in users) {
 			
 			if (u.user.flags.has(flag) ) {
@@ -193,22 +224,32 @@ class Cron extends Controller
 				if (u.user.email != null) {
 					var group = u.distrib.contract.amap;
 
-					var text = "N'oubliez pas la distribution : <b>" + view.hDate(u.distrib.date) + "</b><br>";
-					text += "Vos produits à récupérer :<br><ul>";
-					for ( p in u.products) {
-						text += "<li>"+p.quantity+" x "+p.product.getName();
- 						// Gerer le cas des contrats en alternance
- 						if (p.user2 != null) {
- 							text += " en alternance avec ";
- 							if (u.user == p.user)
- 								text += p.user2.getCoupleName();
- 							else
- 								text += p.user.getCoupleName();
- 						}
- 						text += "</li>";
+					var text;
+					if ( db.User.UserFlags.HasEmailNotifOuverture == flag ) //ouverture de commande
+					{
+						text  = "Ouverture des commandes pour la distribution du : <b>" + view.hDate(u.distrib.date) + "</b><br>";
+						var url = "http://" + App.config.HOST + "/group/"+ u.distrib.contract.amap.id;
+						text += "L'adresse de votre cagette est : <a href=\"" + url + "\">" + url + "</a><br>";
 					}
-					text += "</ul>";
-					
+					else //rappel de la distribution
+					{
+						text = "N'oubliez pas la distribution : <b>" + view.hDate(u.distrib.date) + "</b><br>";
+						text += "Vos produits à récupérer :<br><ul>";
+						for ( p in u.products) {
+							text += "<li>"+p.quantity+" x "+p.product.getName();
+							// Gerer le cas des contrats en alternance
+							if (p.user2 != null) {
+								text += " en alternance avec ";
+								if (u.user == p.user)
+									text += p.user2.getCoupleName();
+								else
+									text += p.user.getCoupleName();
+							}
+							text += "</li>";
+						}
+						text += "</ul>";
+					}
+				
 					if (u.distrib.isDistributor(u.user)) {
 						text += "<b>ATTENTION : Vous ou votre conjoint(e) êtes distributeur ! N'oubliez pas d'imprimer la liste d'émargement.</b>";
 					}
@@ -228,6 +269,7 @@ class Cron extends Controller
 					Sys.sleep(0.25);
 					
 					try {
+						// Comment this line in case of local test
 						App.sendMail(m , u.distrib.contract.amap);	
 					}catch (e:Dynamic){
 						app.logError(e);

--- a/src/db/User.hx
+++ b/src/db/User.hx
@@ -5,6 +5,7 @@ import db.UserAmap;
 enum UserFlags {
 	HasEmailNotif4h;	//send notifications by mail 4h before
 	HasEmailNotif24h;	//send notifications by mail 24h before
+	HasEmailNotifOuverture; //send notifications by mail on command open
 	//Tuto;			//enable tutorials
 }
 
@@ -435,7 +436,7 @@ class User extends Object {
 		
 		//store token
 		var k = sugoi.db.Session.generateId();
-		sugoi.db.Cache.set("validation" + k, this.id, 60 * 60 * 24 * 30); //expire dans un mois
+		sugoi.db.Cache.set("validation" + k, this.id, 60 * 60 * 24 * 30); //expire dans un moisnotifications
 		
 		var e = new sugoi.mail.Mail();
 		if (group == null){

--- a/src/db/User.hx
+++ b/src/db/User.hx
@@ -436,7 +436,7 @@ class User extends Object {
 		
 		//store token
 		var k = sugoi.db.Session.generateId();
-		sugoi.db.Cache.set("validation" + k, this.id, 60 * 60 * 24 * 30); //expire dans un moisnotifications
+		sugoi.db.Cache.set("validation" + k, this.id, 60 * 60 * 24 * 30); //expire dans un mois
 		
 		var e = new sugoi.mail.Mail();
 		if (group == null){


### PR DESCRIPTION
Ceci ajoute la possibilité pour l'utilisateur de recevoir un mail lors de l'ouverture de commandes.
C'est contrôlé par une case à cocher supplémentaire dans le panneau Adhérent
Le mail contient la liste des producteurs prévus.
Faute de maileur fonctionnel, j'ai simulé l'action de la cron table, et vérifiant les données générées par rapport aux données habituellement générées.

J'en ai profité pour corriger un bug sur l’affichage des commits : pour avoir un affichage correct, il ne doit pas commencer par un Digit. Je force donc une lettre.