### PR TITLE
Update for material-ui 0.11.0 and react-next 1.105.0

### DIFF
--- a/js/react/PageHeader.hx
+++ b/js/react/PageHeader.hx
@@ -31,7 +31,7 @@ class PageHeader extends react.ReactComponentOfPropsAndState<PageHeaderProps,{an
         var anchorEl = state.anchorMenu;
 
         return jsx('
-            <$Grid container justify=${css.JustifyContent.Center} style=${{marginBottom:"12px",maxWidth:"1240px",marginLeft:"auto",marginRight:"auto"}}>
+            <$Grid container justify=${Center} style=${{marginBottom:"12px",maxWidth:"1240px",marginLeft:"auto",marginRight:"auto"}}>
                 <$Grid item xs={6}>
                     <h1>${props.groupName}</h1>
                 </$Grid>
@@ -40,7 +40,7 @@ class PageHeader extends react.ReactComponentOfPropsAndState<PageHeaderProps,{an
                         <$Button onClick=$changeGroup >
                             <i className="icon icon-chevron-left"></i>&nbsp;Changer de groupe
                         </$Button>
-                        <$Button onClick=$onUserMenuOpen aria-owns=${anchorEl!=null ? "simple-menu" : null} aria-haspopup="true" >
+                        <$Button onClick=$onUserMenuOpen aria-owns=${anchorEl!=null ? "simple-menu" : null} aria-haspopup>
                             <i className="icon icon-user"></i>&nbsp;${props.userName}
                         </$Button>
                         <$Menu id="simple-menu"

--- a/js/react/store/CartDetails.hx
+++ b/js/react/store/CartDetails.hx
@@ -251,7 +251,7 @@ class CartDetails extends react.ReactComponentOfProps<CartDetailsProps> {
 		//<Grid className=${classes.products} direction=${Column} spacing={8}>
 		return jsx('
 			
-			<GridList cellHeight={80} cols={1} className=${classes.products} direction=${css.FlexDirection.Column} spacing={8}>
+			<GridList cellHeight={80} cols={1} className=${classes.products} spacing={8}>
 				${productsToOrder}
 			</GridList>
 		');


### PR DESCRIPTION
You can test changes by using 
* `react-next` version `1.105.0`
* `react-types` version `0.7.0`
* `material-ui` version `0.11.0`

Most important changes incoming:
* `material-ui`: all components are now implemented and have been updated to `3.7.0` (see [haxe-material-ui gdoc](https://docs.google.com/spreadsheets/d/1qniNk_cEH-YGHVP7u14aGHbOtMxtGcK5cRnN52Kbh5E/edit?usp=sharing))
* `material-ui`: reworked the props system to remove all `@:acceptsMoreProps`. Some html attributes are not yet supported but are not being used here atm. Changes for this are occuring in `react-types`'s [`DOMAttributes`](https://github.com/kLabz/haxe-react-types/blob/master/src/react/types/DOMAttributes.hx)
* `material-ui`: all components include a `style` prop with typings (and enums) from `css-types`
* `DOMEvents` rework, allowing `material-ui`'s enhanced event handlers
* `react-next`: `aria-*` attributes are supported and type-checked against the specs (see [`affd6e4`](https://github.com/kLabz/haxe-react/commit/affd6e4aec92022aa0f025e0a85bf69a8f505aa9))

Further changes planned for future versions:
* More work on `css-types`, especially on `Properties` which is still far from perfect
* `material-ui`: include relevant html attributes for each component if possible, instead of adding them all to all components