### PR TITLE
Include deprecated `ReactMacro.getExtraProps()`

### DIFF
--- a/js/react/CustomReactUtil.hx
+++ b/js/react/CustomReactUtil.hx
@@ -1,0 +1,30 @@
+package react;
+
+import haxe.macro.Context;
+import haxe.macro.Expr;
+import haxe.macro.TypeTools;
+
+class CustomReactUtil {
+	public static macro function getExtraProps(props:Expr):Expr {
+		return switch (Context.typeof(props)) {
+			case _ => Context.followWithAbstracts(_) => TypeTools.toComplexType(_) => TAnonymous(fields):
+				macro {
+					var _tmp = js.Object.assign({}, ${props});
+
+					$a{fields.map(function(f) {
+						return macro untyped __js__('delete {0}[{1}]', _tmp, $v{f.name});
+					})}
+
+					_tmp;
+				};
+
+			default:
+				Context.fatalError(
+					'getExtraProps() expects an anonymous structure as type of argument',
+					Context.currentPos()
+				);
+
+				macro {};
+		};
+	}
+}

--- a/js/react/store/HeaderSubCategoryButton.hx
+++ b/js/react/store/HeaderSubCategoryButton.hx
@@ -83,13 +83,13 @@ class HeaderSubCategoryButton extends ReactComponentOfProps<HeaderSubCategoryBut
 			'${classes.labelChip}': true,
             '${classes.cagSelect}': props.active,
 		});
-        
+
         var iconClasses = classNames({
             '${props.icon}' : true,
             '${classes.icon}': true,
         });
 
-        var others = react.ReactMacro.getExtraProps(props);
+        var others = react.CustomReactUtil.getExtraProps(props);
         var icon = (props.icon != null) ? jsx('<Icon component="i" className=${iconClasses} /> '): null;
         return jsx('
             <a onClick=${props.onclick} className=${linkClasses} {...others}>


### PR DESCRIPTION
@bablukid can you confirm it works with latest `react-next` [git](https://github.com/kLabz/haxe-react) before I release `1.117.0`?